### PR TITLE
fix: capitalize first letter and lowercase all the remaining letters

### DIFF
--- a/.changeset/sour-crabs-begin.md
+++ b/.changeset/sour-crabs-begin.md
@@ -1,0 +1,5 @@
+---
+"moderndash": patch
+---
+
+Fix `capitalize` implementation, lowercasing all remaining letters

--- a/package/src/string/capitalize.ts
+++ b/package/src/string/capitalize.ts
@@ -9,5 +9,5 @@
  */
 
 export function capitalize(str: string): string {
-    return str.charAt(0).toUpperCase() + str.slice(1);
+    return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }

--- a/package/test/string/capitalize.test.ts
+++ b/package/test/string/capitalize.test.ts
@@ -11,3 +11,7 @@ test("returns an empty string for an empty input", () => {
 test("deal with 1 letter", () => {
     expect(capitalize("a")).toBe("A");
 });
+
+test("deal with all uppercase letter, capitalize the first letter and lowercase the remaining", () => {
+    expect(capitalize("FRED")).toBe("Fred");
+});


### PR DESCRIPTION
The [documentation for capitalize](https://moderndash.io/docs/capitalize) states that it should capitalize only the first letter, and lowercasing the remaining letters.

For example `capitalize('FRED')` should returns `Fred`, while the actual current implementation still return `FRED`, because it did nothing to the remaining letters.

This PR update the implementation, to make sure the remaining letters to be lowercased.