### PR TITLE
perf: isEmpty

### DIFF
--- a/package/src/validate/isEmpty.ts
+++ b/package/src/validate/isEmpty.ts
@@ -39,7 +39,16 @@ export function isEmpty(value: string | object | null | undefined): boolean {
         return value.byteLength === 0;
 
     if (typeof value === "object")
-        return Object.keys(value).length === 0;
+        return isObjectEmpty(value);
 
     return false;
+}
+
+function isObjectEmpty(value: object) {
+    for (const key in object) {
+        if (Object.hasOwn(object, key)) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/package/src/validate/isEmpty.ts
+++ b/package/src/validate/isEmpty.ts
@@ -45,8 +45,8 @@ export function isEmpty(value: string | object | null | undefined): boolean {
 }
 
 function isObjectEmpty(value: object) {
-    for (const key in object) {
-        if (Object.hasOwn(object, key)) {
+    for (const key in value) {
+        if (Object.hasOwn(value, key)) {
             return false;
         }
     }


### PR DESCRIPTION
Lots more perf if you avoid `Object.keys(o)` allocations, in particular for large objects.

Sometimes I write the `for .. in` without the if-guard, but it doesn't matter much, engines can usually eliminate that branch from JIT'ted code (not SpiderMonkey though). But as a generic-purpose lib, being correct including all edge-cases is probably more important than being hyper performant.

I would also find it convenient to have `isObjectEmpty` exported on its own, a catch-all `isEmpty` is bound to perform less well than a type-specialized one.